### PR TITLE
Close Settings Modals on Off-tap

### DIFF
--- a/src/main/frontend/components/userSettings/EditEmailModal.js
+++ b/src/main/frontend/components/userSettings/EditEmailModal.js
@@ -19,6 +19,7 @@ function EditEmailModal({emailModalVisible, setEmailModalVisible}) {
     const [email, setEmail] = useState(employeeData.email);
     const [invalidEmail, setInvalidEmail] = useState(false);
     const [originalEmail, setOriginalEmail] = useState(employeeData.email);
+    const [saveError, setSaveError] = useState(false);
 
     const isValueChanged = originalEmail !== email;
 
@@ -26,26 +27,35 @@ function EditEmailModal({emailModalVisible, setEmailModalVisible}) {
         setEmail(originalEmail);
     }
 
+    const handleChangeText = (text) => {
+        setEmail(text);
+        setSaveError(false);
+        setInvalidEmail(false);
+    }
+
     const handleCancel = () => {
         setEmailModalVisible(!emailModalVisible);
         resetEmail();
         setInvalidEmail(false);
+        setSaveError(false);
     }
 
     const handleSubmit = () => {
         const emailPattern = /^[\w\.-]+@[\w\.-]+\.\w+$/;
         const validEmail = emailPattern.test(email);
-        if (!validEmail) {
+        if (!validEmail && !saveError) {
             setInvalidEmail(true);
+            setSaveError(true);
             Haptics.notificationAsync(
                 Haptics.NotificationFeedbackType.Error
             );
-        } else if (isValueChanged) {
+        } else if (isValueChanged && !saveError) {
             setEmailModalVisible(!emailModalVisible);
             Haptics.notificationAsync(
                 Haptics.NotificationFeedbackType.Success
             );
             setInvalidEmail(false);
+            setSaveError(false);
             setOriginalEmail(email);
         }
     }
@@ -69,7 +79,7 @@ function EditEmailModal({emailModalVisible, setEmailModalVisible}) {
                                 <TextInput
                                     style={[styles.inputText, invalidEmail ? styles.errorBorder : null]}
                                     autoCapitalize={"none"}
-                                    onChangeText={setEmail}
+                                    onChangeText={handleChangeText}
                                     value={email}
                                     placeholder="ex. johndoe@email.com"
                                     placeholderTextColor={secondaryGray}
@@ -77,7 +87,7 @@ function EditEmailModal({emailModalVisible, setEmailModalVisible}) {
                                     inputMode={"email"}
                                 />
                                 <View style={[styles.submitButton,
-                                    isValueChanged ? {backgroundColor: primaryGreen}
+                                    (isValueChanged && !saveError) ? {backgroundColor: primaryGreen}
                                         : {backgroundColor: grayAction}]}>
                                     <TouchableOpacity
                                         style={[{width: "100%"}, {alignItems: "center"}]}

--- a/src/main/frontend/components/userSettings/EditEmailModal.js
+++ b/src/main/frontend/components/userSettings/EditEmailModal.js
@@ -27,7 +27,7 @@ function EditEmailModal({emailModalVisible, setEmailModalVisible}) {
         setEmail(originalEmail);
     }
 
-    const handleChangeText = (text) => {
+    const handleOnChangeText = (text) => {
         setEmail(text);
         setSaveError(false);
         setInvalidEmail(false);
@@ -79,7 +79,7 @@ function EditEmailModal({emailModalVisible, setEmailModalVisible}) {
                                 <TextInput
                                     style={[styles.inputText, invalidEmail ? styles.errorBorder : null]}
                                     autoCapitalize={"none"}
-                                    onChangeText={handleChangeText}
+                                    onChangeText={handleOnChangeText}
                                     value={email}
                                     placeholder="ex. johndoe@email.com"
                                     placeholderTextColor={secondaryGray}

--- a/src/main/frontend/components/userSettings/EditEmailModal.js
+++ b/src/main/frontend/components/userSettings/EditEmailModal.js
@@ -60,8 +60,7 @@ function EditEmailModal({emailModalVisible, setEmailModalVisible}) {
             }}>
             <KeyboardAvoidingView
                 behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-                style={styles.container}
-            >
+                style={styles.container}>
                 <TouchableWithoutFeedback onPress={handleCancel}>
                     <View style={styles.centeredView}>
                         <TouchableWithoutFeedback>

--- a/src/main/frontend/components/userSettings/EditEmailModal.js
+++ b/src/main/frontend/components/userSettings/EditEmailModal.js
@@ -11,8 +11,6 @@ import {
 } from "react-native";
 import * as Haptics from "expo-haptics";
 import {black, destructiveAction, grayAction, primaryGreen, secondaryGray, white} from "../../utils/Colors";
-import {FontAwesomeIcon} from "@fortawesome/react-native-fontawesome";
-import {Check, XMark} from "../../utils/Icons";
 import employeeData from "../../mockApiCalls/employeeData.json";
 
 function EditEmailModal({emailModalVisible, setEmailModalVisible}) {

--- a/src/main/frontend/components/userSettings/EditEmailModal.js
+++ b/src/main/frontend/components/userSettings/EditEmailModal.js
@@ -132,7 +132,7 @@ const styles = StyleSheet.create({
         elevation: 5,
     },
     modalText: {
-        marginBottom: 24,
+        marginBottom: 18,
         textAlign: 'center',
         fontSize: 24,
         fontWeight: "500",

--- a/src/main/frontend/components/userSettings/EditEmailModal.js
+++ b/src/main/frontend/components/userSettings/EditEmailModal.js
@@ -7,10 +7,10 @@ import {
     TouchableOpacity,
     View,
     Platform,
-    KeyboardAvoidingView,
+    KeyboardAvoidingView, TouchableWithoutFeedback,
 } from "react-native";
 import * as Haptics from "expo-haptics";
-import {black, destructiveAction, primaryGreen, secondaryGray} from "../../utils/Colors";
+import {black, destructiveAction, grayAction, primaryGreen, secondaryGray, white} from "../../utils/Colors";
 import {FontAwesomeIcon} from "@fortawesome/react-native-fontawesome";
 import {Check, XMark} from "../../utils/Icons";
 import employeeData from "../../mockApiCalls/employeeData.json";
@@ -19,6 +19,8 @@ function EditEmailModal({emailModalVisible, setEmailModalVisible}) {
     const [email, setEmail] = useState(employeeData.email);
     const [invalidEmail, setInvalidEmail] = useState(false);
     const [originalEmail, setOriginalEmail] = useState(employeeData.email);
+
+    const isValueChanged = originalEmail !== email;
 
     const resetEmail = () => {
         setEmail(originalEmail);
@@ -38,12 +40,13 @@ function EditEmailModal({emailModalVisible, setEmailModalVisible}) {
             Haptics.notificationAsync(
                 Haptics.NotificationFeedbackType.Error
             );
-        } else {
+        } else if (isValueChanged) {
             setEmailModalVisible(!emailModalVisible);
             Haptics.notificationAsync(
                 Haptics.NotificationFeedbackType.Success
             );
             setInvalidEmail(false);
+            setOriginalEmail(email);
         }
     }
 
@@ -57,34 +60,36 @@ function EditEmailModal({emailModalVisible, setEmailModalVisible}) {
             }}>
             <KeyboardAvoidingView
                 behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-                style={styles.container}>
-                <View style={styles.centeredView}>
-                    <View style={styles.modalView}>
-                        <Text style={styles.modalText}>Edit Email</Text>
-                        <TextInput
-                            style={[styles.inputText, invalidEmail ? styles.errorBorder : null]}
-                            autoCapitalize={"none"}
-                            onChangeText={setEmail}
-                            value={email}
-                            placeholder="ex. johndoe@email.com"
-                            placeholderTextColor={secondaryGray}
-                            autoComplete={"email"}
-                            inputMode={"email"}
-                        />
-                        <View style={styles.buttonsContainer}>
-                            <TouchableOpacity
-                                style={styles.buttonCancel}
-                                onPress={handleCancel}>
-                                <FontAwesomeIcon icon={XMark} size={32} color={destructiveAction} />
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                                style={styles.buttonSubmit}
-                                onPress={handleSubmit}>
-                                <FontAwesomeIcon icon={Check} size={32} color={primaryGreen} />
-                            </TouchableOpacity>
-                        </View>
+                style={styles.container}
+            >
+                <TouchableWithoutFeedback onPress={handleCancel}>
+                    <View style={styles.centeredView}>
+                        <TouchableWithoutFeedback>
+                            <View style={styles.modalView}>
+                                <Text style={styles.modalText}>Edit Email</Text>
+                                <TextInput
+                                    style={[styles.inputText, invalidEmail ? styles.errorBorder : null]}
+                                    autoCapitalize={"none"}
+                                    onChangeText={setEmail}
+                                    value={email}
+                                    placeholder="ex. johndoe@email.com"
+                                    placeholderTextColor={secondaryGray}
+                                    autoComplete={"email"}
+                                    inputMode={"email"}
+                                />
+                                <View style={[styles.submitButton,
+                                    isValueChanged ? {backgroundColor: primaryGreen}
+                                        : {backgroundColor: grayAction}]}>
+                                    <TouchableOpacity
+                                        style={[{width: "100%"}, {alignItems: "center"}]}
+                                        onPress={handleSubmit}>
+                                        <Text style={styles.submitText}>Save</Text>
+                                    </TouchableOpacity>
+                                </View>
+                            </View>
+                        </TouchableWithoutFeedback>
                     </View>
-                </View>
+                </TouchableWithoutFeedback>
             </KeyboardAvoidingView>
         </Modal>
     )
@@ -118,32 +123,28 @@ const styles = StyleSheet.create({
         elevation: 5,
     },
     modalText: {
-        marginBottom: 16,
+        marginBottom: 24,
         textAlign: 'center',
         fontSize: 24,
         fontWeight: "500",
     },
-    buttonSubmit: {
-        width: "50%",
+    submitButton: {
+        width: "100%",
+        borderRadius: 10,
+        marginBottom: 24,
         padding: 12,
         alignItems: "center",
-        paddingRight: 0,
     },
-    buttonCancel: {
-        width: "50%",
-        padding: 12,
-        alignItems: "center",
-        paddingLeft: 0,
-    },
-    buttonsContainer: {
-        flexDirection: "row",
-        paddingTop: 12,
+    submitText: {
+        fontSize: 24,
+        fontWeight: "500",
+        color: white,
     },
     inputText: {
-        width: "85%",
+        width: "100%",
         fontSize: 18,
         padding: 8,
-        marginBottom: 16,
+        marginBottom: 24,
         borderWidth: 2,
         borderColor: secondaryGray,
         borderRadius: 10,

--- a/src/main/frontend/components/userSettings/EditNameModal.js
+++ b/src/main/frontend/components/userSettings/EditNameModal.js
@@ -23,6 +23,8 @@ function EditNameModal({nameModalVisible, setNameModalVisible}) {
     const [originalFName, setOriginalFName] = useState(employeeData.fName);
     const [originalLName, setOriginalLName] = useState(employeeData.lName);
 
+    const isValueChanged = (originalFName !== fName) || (originalLName !== lName);
+
     const resetFName = () => {
         setFName(originalFName);
     };
@@ -50,13 +52,15 @@ function EditNameModal({nameModalVisible, setNameModalVisible}) {
             Haptics.notificationAsync(
                 Haptics.NotificationFeedbackType.Error
             );
-        } else {
+        } else if (isValueChanged) {
             setNameModalVisible(!nameModalVisible);
             Haptics.notificationAsync(
                 Haptics.NotificationFeedbackType.Success
             );
             setEmptyFName(false);
             setEmptyLName(false);
+            setOriginalFName(fName);
+            setOriginalLName(lName);
         }
     }
 

--- a/src/main/frontend/components/userSettings/EditNameModal.js
+++ b/src/main/frontend/components/userSettings/EditNameModal.js
@@ -152,7 +152,7 @@ const styles = StyleSheet.create({
         elevation: 5,
     },
     modalText: {
-        marginBottom: 24,
+        marginBottom: 18,
         textAlign: 'center',
         fontSize: 24,
         fontWeight: "500",

--- a/src/main/frontend/components/userSettings/EditNameModal.js
+++ b/src/main/frontend/components/userSettings/EditNameModal.js
@@ -11,8 +11,6 @@ import {
 } from "react-native";
 import * as Haptics from 'expo-haptics';
 import {black, destructiveAction, grayAction, primaryGreen, secondaryGray, white} from "../../utils/Colors";
-import {FontAwesomeIcon} from "@fortawesome/react-native-fontawesome";
-import {Check, XMark} from "../../utils/Icons";
 import employeeData from "../../mockApiCalls/employeeData.json";
 
 function EditNameModal({nameModalVisible, setNameModalVisible}) {

--- a/src/main/frontend/components/userSettings/EditNameModal.js
+++ b/src/main/frontend/components/userSettings/EditNameModal.js
@@ -22,6 +22,8 @@ function EditNameModal({nameModalVisible, setNameModalVisible}) {
     const [emptyLName, setEmptyLName] = useState(false);
     const [originalFName, setOriginalFName] = useState(employeeData.fName);
     const [originalLName, setOriginalLName] = useState(employeeData.lName);
+    const [fNameSaveError, setFNameSaveError] = useState(false);
+    const [lNameSaveError, setLNameSaveError] = useState(false);
 
     const isValueChanged = (originalFName !== fName) || (originalLName !== lName);
 
@@ -33,32 +35,50 @@ function EditNameModal({nameModalVisible, setNameModalVisible}) {
         setLName(originalLName);
     };
 
+    const onHandleChangeTextFName = (text) => {
+        setFName(text);
+        setFNameSaveError(false);
+        setEmptyFName(false);
+    }
+
+    const onHandleChangeTextLName = (text) => {
+        setLName(text);
+        setLNameSaveError(false);
+        setEmptyLName(false);
+    }
+
     const handleCancel = () => {
         setNameModalVisible(!nameModalVisible);
         resetFName();
         resetLName();
         setEmptyFName(false);
         setEmptyLName(false);
+        setFNameSaveError(false);
+        setLNameSaveError(false);
     }
 
     const handleSubmit = () => {
-        if (fName.trim() === '') {
+        if (fName.trim() === '' && !fNameSaveError) {
             setEmptyFName(true);
+            setFNameSaveError(true);
             Haptics.notificationAsync(
                 Haptics.NotificationFeedbackType.Error
             );
-        } else if (lName.trim() === '') {
+        } else if (lName.trim() === '' && !lNameSaveError) {
             setEmptyLName(true);
+            setLNameSaveError(true);
             Haptics.notificationAsync(
                 Haptics.NotificationFeedbackType.Error
             );
-        } else if (isValueChanged) {
+        } else if (isValueChanged  && !fNameSaveError && !lNameSaveError) {
             setNameModalVisible(!nameModalVisible);
             Haptics.notificationAsync(
                 Haptics.NotificationFeedbackType.Success
             );
             setEmptyFName(false);
             setEmptyLName(false);
+            setFNameSaveError(false);
+            setLNameSaveError(false);
             setOriginalFName(fName);
             setOriginalLName(lName);
         }
@@ -85,10 +105,7 @@ function EditNameModal({nameModalVisible, setNameModalVisible}) {
                                 <TextInput
                                     style={[styles.inputText, emptyFName ? styles.errorBorder : null]}
                                     autoCapitalize={"words"}
-                                    onChangeText={(fName) => {
-                                        setFName(fName);
-                                        setEmptyFName(false);
-                                    }}
+                                    onChangeText={onHandleChangeTextFName}
                                     value={fName}
                                     placeholder="First Name"
                                     placeholderTextColor={secondaryGray}
@@ -97,17 +114,14 @@ function EditNameModal({nameModalVisible, setNameModalVisible}) {
                                 <TextInput
                                     style={[styles.inputText, emptyLName ? styles.errorBorder : null]}
                                     autoCapitalize={"words"}
-                                    onChangeText={(lName) => {
-                                        setLName(lName);
-                                        setEmptyLName(false);
-                                    }}
+                                    onChangeText={onHandleChangeTextLName}
                                     value={lName}
                                     placeholder="Last Name"
                                     placeholderTextColor={secondaryGray}
                                     autoComplete={"name-family"}
                                 />
                                 <View style={[styles.submitButton,
-                                    isValueChanged ? {backgroundColor: primaryGreen}
+                                    (isValueChanged && !fNameSaveError && !lNameSaveError) ? {backgroundColor: primaryGreen}
                                         : {backgroundColor: grayAction}]}>
                                     <TouchableOpacity
                                         style={[{width: "100%"}, {alignItems: "center"}]}

--- a/src/main/frontend/components/userSettings/EditNameModal.js
+++ b/src/main/frontend/components/userSettings/EditNameModal.js
@@ -7,7 +7,7 @@ import {
     TouchableOpacity,
     View,
     KeyboardAvoidingView,
-    Platform
+    Platform, TouchableWithoutFeedback
 } from "react-native";
 import * as Haptics from 'expo-haptics';
 import {black, destructiveAction, primaryGreen, secondaryGray} from "../../utils/Colors";
@@ -71,51 +71,59 @@ function EditNameModal({nameModalVisible, setNameModalVisible}) {
             visible={nameModalVisible}
             onRequestClose={() => {
                 setNameModalVisible(!nameModalVisible);
-            }}>
+            }}
+        >
             <KeyboardAvoidingView
                 behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-                style={styles.container}>
-                <View style={styles.centeredView}>
-                    <View style={styles.modalView}>
-                        <Text style={styles.modalText}>Edit Name</Text>
-                        <TextInput
-                            style={[styles.inputText, emptyFName ? styles.errorBorder : null]}
-                            autoCapitalize={"words"}
-                            onChangeText={(fName) => {
-                                setFName(fName);
-                                setEmptyFName(false);
-                            }}
-                            value={fName}
-                            placeholder="First Name"
-                            placeholderTextColor={secondaryGray}
-                            autoComplete={"name-given"}
-                        />
-                        <TextInput
-                            style={[styles.inputText, emptyLName ? styles.errorBorder : null]}
-                            autoCapitalize={"words"}
-                            onChangeText={(lName) => {
-                                setLName(lName);
-                                setEmptyLName(false);
-                            }}
-                            value={lName}
-                            placeholder="Last Name"
-                            placeholderTextColor={secondaryGray}
-                            autoComplete={"name-family"}
-                        />
-                        <View style={styles.buttonsContainer}>
-                            <TouchableOpacity
-                                style={styles.buttonCancel}
-                                onPress={handleCancel}>
-                                <FontAwesomeIcon icon={XMark} size={32} color={destructiveAction} />
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                                style={styles.buttonSubmit}
-                                onPress={handleSubmit}>
-                                <FontAwesomeIcon icon={Check} size={32} color={primaryGreen} />
-                            </TouchableOpacity>
-                        </View>
+                style={styles.container}
+            >
+                <TouchableWithoutFeedback onPress={handleCancel}>
+                    <View style={styles.centeredView}>
+                        <TouchableWithoutFeedback>
+                            <View style={styles.modalView}>
+                                <Text style={styles.modalText}>Edit Name</Text>
+                                <TextInput
+                                    style={[styles.inputText, emptyFName ? styles.errorBorder : null]}
+                                    autoCapitalize={"words"}
+                                    onChangeText={(fName) => {
+                                        setFName(fName);
+                                        setEmptyFName(false);
+                                    }}
+                                    value={fName}
+                                    placeholder="First Name"
+                                    placeholderTextColor={secondaryGray}
+                                    autoComplete={"name-given"}
+                                />
+                                <TextInput
+                                    style={[styles.inputText, emptyLName ? styles.errorBorder : null]}
+                                    autoCapitalize={"words"}
+                                    onChangeText={(lName) => {
+                                        setLName(lName);
+                                        setEmptyLName(false);
+                                    }}
+                                    value={lName}
+                                    placeholder="Last Name"
+                                    placeholderTextColor={secondaryGray}
+                                    autoComplete={"name-family"}
+                                />
+                                <View style={styles.buttonsContainer}>
+                                    <TouchableOpacity
+                                        style={styles.buttonCancel}
+                                        onPress={handleCancel}
+                                    >
+                                        <FontAwesomeIcon icon={XMark} size={32} color={destructiveAction} />
+                                    </TouchableOpacity>
+                                    <TouchableOpacity
+                                        style={styles.buttonSubmit}
+                                        onPress={handleSubmit}
+                                    >
+                                        <FontAwesomeIcon icon={Check} size={32} color={primaryGreen} />
+                                    </TouchableOpacity>
+                                </View>
+                            </View>
+                        </TouchableWithoutFeedback>
                     </View>
-                </View>
+                </TouchableWithoutFeedback>
             </KeyboardAvoidingView>
         </Modal>
     )

--- a/src/main/frontend/components/userSettings/EditNameModal.js
+++ b/src/main/frontend/components/userSettings/EditNameModal.js
@@ -10,7 +10,7 @@ import {
     Platform, TouchableWithoutFeedback
 } from "react-native";
 import * as Haptics from 'expo-haptics';
-import {black, destructiveAction, primaryGreen, secondaryGray} from "../../utils/Colors";
+import {black, destructiveAction, grayAction, primaryGreen, secondaryGray, white} from "../../utils/Colors";
 import {FontAwesomeIcon} from "@fortawesome/react-native-fontawesome";
 import {Check, XMark} from "../../utils/Icons";
 import employeeData from "../../mockApiCalls/employeeData.json";
@@ -106,18 +106,13 @@ function EditNameModal({nameModalVisible, setNameModalVisible}) {
                                     placeholderTextColor={secondaryGray}
                                     autoComplete={"name-family"}
                                 />
-                                <View style={styles.buttonsContainer}>
+                                <View style={[styles.submitButton,
+                                    isValueChanged ? {backgroundColor: primaryGreen}
+                                        : {backgroundColor: grayAction}]}>
                                     <TouchableOpacity
-                                        style={styles.buttonCancel}
-                                        onPress={handleCancel}
-                                    >
-                                        <FontAwesomeIcon icon={XMark} size={32} color={destructiveAction} />
-                                    </TouchableOpacity>
-                                    <TouchableOpacity
-                                        style={styles.buttonSubmit}
-                                        onPress={handleSubmit}
-                                    >
-                                        <FontAwesomeIcon icon={Check} size={32} color={primaryGreen} />
+                                        style={[{width: "100%"}, {alignItems: "center"}]}
+                                        onPress={handleSubmit}>
+                                        <Text style={styles.submitText}>Save</Text>
                                     </TouchableOpacity>
                                 </View>
                             </View>
@@ -157,32 +152,29 @@ const styles = StyleSheet.create({
         elevation: 5,
     },
     modalText: {
-        marginBottom: 16,
+        marginBottom: 24,
         textAlign: 'center',
         fontSize: 24,
         fontWeight: "500",
     },
-    buttonSubmit: {
-        width: "50%",
+    submitButton: {
+        width: "100%",
+        borderRadius: 10,
+        marginBottom: 24,
+        marginTop: 12,
         padding: 12,
         alignItems: "center",
-        paddingRight: 0,
     },
-    buttonCancel: {
-        width: "50%",
-        padding: 12,
-        alignItems: "center",
-        paddingLeft: 0,
-    },
-    buttonsContainer: {
-        flexDirection: "row",
-        paddingTop: 12,
+    submitText: {
+        fontSize: 24,
+        fontWeight: "500",
+        color: white,
     },
     inputText: {
-        width: "85%",
+        width: "100%",
         fontSize: 18,
         padding: 8,
-        marginBottom: 16,
+        marginBottom: 18,
         borderWidth: 2,
         borderColor: secondaryGray,
         borderRadius: 10,

--- a/src/main/frontend/components/userSettings/EditPhoneNumberModal.js
+++ b/src/main/frontend/components/userSettings/EditPhoneNumberModal.js
@@ -17,6 +17,7 @@ function EditPhoneNumberModal({phoneNumberModalVisible, setPhoneNumberModalVisib
     const [phoneNumber, setPhoneNumber] = useState(employeeData.phoneNumber);
     const [invalidPhoneNumber, setInvalidPhoneNumber] = useState(false);
     const [originalPhoneNumber, setOriginalPhoneNumber] = useState(employeeData.phoneNumber);
+    const [saveError, setSaveError] = useState(false);
 
     const isValueChanged = originalPhoneNumber !== phoneNumber;
 
@@ -24,26 +25,36 @@ function EditPhoneNumberModal({phoneNumberModalVisible, setPhoneNumberModalVisib
         setPhoneNumber(originalPhoneNumber);
     }
 
+    const handleOnChangeText = (text) => {
+            setPhoneNumber(text);
+            setSaveError(false);
+            setInvalidPhoneNumber(false);
+    }
+
     const handleCancel = () => {
         setPhoneNumberModalVisible(!phoneNumberModalVisible);
         resetPhoneNumber();
         setInvalidPhoneNumber(false);
+        setSaveError(false);
     }
 
     const handleSubmit = () => {
         const phoneNumberPattern = /^\d{10}$/;
         const validPhoneNumber = phoneNumberPattern.test(phoneNumber);
-        if(!validPhoneNumber) {
+        if(!validPhoneNumber && !saveError) {
             setInvalidPhoneNumber(true);
+            setSaveError(true);
             Haptics.notificationAsync(
                 Haptics.NotificationFeedbackType.Error
             );
-        } else {
+        } else if (isValueChanged && !saveError) {
             setPhoneNumberModalVisible(!phoneNumberModalVisible);
             Haptics.notificationAsync(
                 Haptics.NotificationFeedbackType.Success
             );
             setInvalidPhoneNumber(false);
+            setSaveError(false);
+            setOriginalPhoneNumber(phoneNumber);
         }
     }
 
@@ -66,7 +77,7 @@ function EditPhoneNumberModal({phoneNumberModalVisible, setPhoneNumberModalVisib
                                 <TextInput
                                     style={[styles.inputText, invalidPhoneNumber ? styles.errorBorder : null]}
                                     autoCapitalize={"words"}
-                                    onChangeText={setPhoneNumber}
+                                    onChangeText={handleOnChangeText}
                                     value={phoneNumber}
                                     placeholder="ex. 5555555555"
                                     placeholderTextColor={secondaryGray}
@@ -74,7 +85,7 @@ function EditPhoneNumberModal({phoneNumberModalVisible, setPhoneNumberModalVisib
                                     inputMode={"tel"}
                                 />
                                 <View style={[styles.submitButton,
-                                    isValueChanged ? {backgroundColor: primaryGreen}
+                                    (isValueChanged && !saveError) ? {backgroundColor: primaryGreen}
                                         : {backgroundColor: grayAction}]}>
                                     <TouchableOpacity
                                         style={[{width: "100%"}, {alignItems: "center"}]}

--- a/src/main/frontend/components/userSettings/EditPhoneNumberModal.js
+++ b/src/main/frontend/components/userSettings/EditPhoneNumberModal.js
@@ -10,15 +10,15 @@ import {
     KeyboardAvoidingView, TouchableWithoutFeedback,
 } from "react-native";
 import * as Haptics from "expo-haptics";
-import {black, destructiveAction, primaryGreen, secondaryGray} from "../../utils/Colors";
-import {FontAwesomeIcon} from "@fortawesome/react-native-fontawesome";
-import {Check, XMark} from "../../utils/Icons";
+import {black, destructiveAction, grayAction, primaryGreen, secondaryGray, white} from "../../utils/Colors";
 import employeeData from "../../mockApiCalls/employeeData.json";
 
 function EditPhoneNumberModal({phoneNumberModalVisible, setPhoneNumberModalVisible}) {
     const [phoneNumber, setPhoneNumber] = useState(employeeData.phoneNumber);
     const [invalidPhoneNumber, setInvalidPhoneNumber] = useState(false);
     const [originalPhoneNumber, setOriginalPhoneNumber] = useState(employeeData.phoneNumber);
+
+    const isValueChanged = originalPhoneNumber !== phoneNumber;
 
     const resetPhoneNumber = () => {
         setPhoneNumber(originalPhoneNumber);
@@ -73,16 +73,13 @@ function EditPhoneNumberModal({phoneNumberModalVisible, setPhoneNumberModalVisib
                                     autoComplete={"tel"}
                                     inputMode={"tel"}
                                 />
-                                <View style={styles.buttonsContainer}>
+                                <View style={[styles.submitButton,
+                                    isValueChanged ? {backgroundColor: primaryGreen}
+                                        : {backgroundColor: grayAction}]}>
                                     <TouchableOpacity
-                                        style={styles.buttonCancel}
-                                        onPress={handleCancel}>
-                                        <FontAwesomeIcon icon={XMark} size={32} color={destructiveAction} />
-                                    </TouchableOpacity>
-                                    <TouchableOpacity
-                                        style={styles.buttonSubmit}
+                                        style={[{width: "100%"}, {alignItems: "center"}]}
                                         onPress={handleSubmit}>
-                                        <FontAwesomeIcon icon={Check} size={32} color={primaryGreen} />
+                                        <Text style={styles.submitText}>Save</Text>
                                     </TouchableOpacity>
                                 </View>
                             </View>
@@ -122,32 +119,28 @@ const styles = StyleSheet.create({
         elevation: 5,
     },
     modalText: {
-        marginBottom: 16,
+        marginBottom: 18,
         textAlign: 'center',
         fontSize: 24,
         fontWeight: "500",
     },
-    buttonSubmit: {
-        width: "50%",
+    submitButton: {
+        width: "100%",
+        borderRadius: 10,
+        marginBottom: 24,
         padding: 12,
         alignItems: "center",
-        paddingRight: 0,
     },
-    buttonCancel: {
-        width: "50%",
-        padding: 12,
-        alignItems: "center",
-        paddingLeft: 0,
-    },
-    buttonsContainer: {
-        flexDirection: "row",
-        paddingTop: 12,
+    submitText: {
+        fontSize: 24,
+        fontWeight: "500",
+        color: white,
     },
     inputText: {
-        width: "85%",
+        width: "100%",
         fontSize: 18,
         padding: 8,
-        marginBottom: 16,
+        marginBottom: 24,
         borderWidth: 2,
         borderColor: secondaryGray,
         borderRadius: 10,

--- a/src/main/frontend/components/userSettings/EditPhoneNumberModal.js
+++ b/src/main/frontend/components/userSettings/EditPhoneNumberModal.js
@@ -7,10 +7,10 @@ import {
     TouchableOpacity,
     View,
     Platform,
-    KeyboardAvoidingView,
+    KeyboardAvoidingView, TouchableWithoutFeedback,
 } from "react-native";
 import * as Haptics from "expo-haptics";
-import {black, destructiveAction, grayAction, primaryGreen, secondaryGray} from "../../utils/Colors";
+import {black, destructiveAction, primaryGreen, secondaryGray} from "../../utils/Colors";
 import {FontAwesomeIcon} from "@fortawesome/react-native-fontawesome";
 import {Check, XMark} from "../../utils/Icons";
 import employeeData from "../../mockApiCalls/employeeData.json";
@@ -58,33 +58,37 @@ function EditPhoneNumberModal({phoneNumberModalVisible, setPhoneNumberModalVisib
             <KeyboardAvoidingView
                 behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
                 style={styles.container}>
-                <View style={styles.centeredView}>
-                    <View style={styles.modalView}>
-                        <Text style={styles.modalText}>Edit Phone Number</Text>
-                        <TextInput
-                            style={[styles.inputText, invalidPhoneNumber ? styles.errorBorder : null]}
-                            autoCapitalize={"words"}
-                            onChangeText={setPhoneNumber}
-                            value={phoneNumber}
-                            placeholder="ex. 5555555555"
-                            placeholderTextColor={secondaryGray}
-                            autoComplete={"tel"}
-                            inputMode={"tel"}
-                        />
-                        <View style={styles.buttonsContainer}>
-                            <TouchableOpacity
-                                style={styles.buttonCancel}
-                                onPress={handleCancel}>
-                                <FontAwesomeIcon icon={XMark} size={32} color={destructiveAction} />
-                            </TouchableOpacity>
-                            <TouchableOpacity
-                                style={styles.buttonSubmit}
-                                onPress={handleSubmit}>
-                                <FontAwesomeIcon icon={Check} size={32} color={primaryGreen} />
-                            </TouchableOpacity>
-                        </View>
+                <TouchableWithoutFeedback onPress={handleCancel}>
+                    <View style={styles.centeredView}>
+                        <TouchableWithoutFeedback>
+                            <View style={styles.modalView}>
+                                <Text style={styles.modalText}>Edit Phone Number</Text>
+                                <TextInput
+                                    style={[styles.inputText, invalidPhoneNumber ? styles.errorBorder : null]}
+                                    autoCapitalize={"words"}
+                                    onChangeText={setPhoneNumber}
+                                    value={phoneNumber}
+                                    placeholder="ex. 5555555555"
+                                    placeholderTextColor={secondaryGray}
+                                    autoComplete={"tel"}
+                                    inputMode={"tel"}
+                                />
+                                <View style={styles.buttonsContainer}>
+                                    <TouchableOpacity
+                                        style={styles.buttonCancel}
+                                        onPress={handleCancel}>
+                                        <FontAwesomeIcon icon={XMark} size={32} color={destructiveAction} />
+                                    </TouchableOpacity>
+                                    <TouchableOpacity
+                                        style={styles.buttonSubmit}
+                                        onPress={handleSubmit}>
+                                        <FontAwesomeIcon icon={Check} size={32} color={primaryGreen} />
+                                    </TouchableOpacity>
+                                </View>
+                            </View>
+                        </TouchableWithoutFeedback>
                     </View>
-                </View>
+                </TouchableWithoutFeedback>
             </KeyboardAvoidingView>
         </Modal>
     )


### PR DESCRIPTION
The settings modals have been updated so that they now close (and cancel) when tapped away from. 

They have also been updated so that the new save button turns gray and does not close the modal if the user tries to submit an invalid input. It also stays gray and inactive so long as the user does not update the entered text.